### PR TITLE
Cache the whole cargo registry, including the src folder

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,8 +50,7 @@ runs:
       with:
         path: |
           ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
+          ~/.cargo/registry/
           ~/.cargo/git/db/
           target/
         # Update the cache every time the `Cargo.lock` file changes (i.e., the dependencies change).


### PR DESCRIPTION
This is an attempt to fix the caching for the `cargo udeps` command, which has to run on nightly.