### PR TITLE
Add option to specify `CARGO_HOME` and `CARGO_TARGET_DIR`  locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ jobs:
 
 ## Inputs
 
-| Name          | Description                                                                                                                  | Type     | Default             |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `cache-group` | The group of the cache, defaults to the job ID. If you want two jobs to share the same cache, give them the same group name. | `string` | `${{ github.job }}` |
+| Name               | Description                                                                                                                                                                                                                                                   | Type     | Default             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| `cache-group`      | The group of the cache, defaults to the job ID. If you want two jobs to share the same cache, give them the same group name.                                                                                                                                  | `string` | `${{ github.job }}` |
+| `cargo-home`       | The location of the Cargo cache files. If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory.                                                               | `string` | `~/.cargo`          |
+| `cargo-target-dir` | Location of where to place all generated artifacts, relative to the current working directory. If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory. | `string` | `target`            |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,22 @@ inputs:
       If you want two jobs to share the same cache, give them the same group name.
     required: false
     default: ${{ github.job }}
+  cargo-home:
+    description: |
+      The location of the Cargo cache files.
+      If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too.
+      This must NOT end with the trailing slash of the directory.
+      Defaults to `~/.cargo`.
+    required: false
+    default: ~/.cargo
+  cargo-target-dir:
+    description: |
+      Location of where to place all generated artifacts, relative to the current working directory. 
+      If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too.
+      This must NOT end with the trailing slash of the directory.
+      Defaults to `target`.
+    required: false
+    default: target
 outputs:
   cache-hit:
     description: |
@@ -49,11 +65,11 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
+          ${{ inputs.cargo-home }}/bin/
+          ${{ inputs.cargo-home }}/registry/index/
+          ${{ inputs.cargo-home }}/registry/cache/
+          ${{ inputs.cargo-home }}/git/db/
+          ${{ inputs.cargo-target-dir }}/
         # Update the cache every time the `Cargo.lock` file changes (i.e., the dependencies change).
         # We also include the `Cargo.toml` files in the hash in case the compile configurations change.
         key: ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
Closes #8.

This PR adds two new inputs, `cargo-home` and `cargo-target-dir`, which correspond to the `CARGO_HOME` and `CARGO_TARGET_DIR` environment variables.
If a user sets these variables for any CI workflow, they can cache those locations instead.