### PR TITLE
Make the cargo version part of the cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ When the `Cargo.toml` or `Cargo.lock` files change, the cache falls back to prev
 When the `Cargo.lock` file was not committed to the repository (this is the case for libraries), it is first generated via `cargo update`.
 This is why the `dtolnay/rust-toolchain` action must be used _before_ this action.
 For more information on why the `Cargo.toml` files don't specify the dependencies completely, please consult [the Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html).
+
+Additionally, the Rust version reported by Cargo is included in the cache key.
+This prevents the cache from being outdated when a new Rust version is released, as this will result in a re-compile of all dependencies.

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
         version=$(cargo --version | grep -oE "\(([a-z0-9]+) [0-9-]+\)")
 
         # Write the extracted version to a GitHub output variable
+        # See <https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions>
         echo "cargo-version=$(echo $version)" >> $GITHUB_OUTPUT
 
     # See <https://github.com/actions/cache>.

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,22 @@ runs:
             fi
         fi
 
+    # The dependencies are recompiled if a new Rust version is used
+    # This steps determines the Cargo version to include it in the cache key
+    - name: Get cargo version
+      id: cargo-version
+      shell: bash
+      run: |
+        # Print version once for debugging
+        cargo --version
+
+        # Extract the commit hash and date of the cargo version
+        # E.g. "cargo 1.72.0-nightly (0c14026aa 2023-06-14)" becomes "(0c14026aa 2023-06-14)"
+        version=$(cargo --version | grep -oE "\(([a-z0-9]+) [0-9-]+\)")
+
+        # Write the extracted version to a GitHub output variable
+        echo "cargo-version=$(echo $version)" >> $GITHUB_OUTPUT
+
     # See <https://github.com/actions/cache>.
     - name: Create cache
       id: cache
@@ -72,8 +88,9 @@ runs:
           ${{ inputs.cargo-target-dir }}/
         # Update the cache every time the `Cargo.lock` file changes (i.e., the dependencies change).
         # We also include the `Cargo.toml` files in the hash in case the compile configurations change.
-        key: ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        # The Cargo version is also included in the hash, because a version change causes re-compiles
+        key: ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         # Restore caches from the same group.
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-
-          ${{ runner.os }}-${{ inputs.cache-group }}-
+          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-


### PR DESCRIPTION
Fixes #12.

We often had the trouble that the dependencies kept getting re-compiled, because a new Rust version was released.
This meant that the existing cache would stay invalid, but was never re-generated.

This PR includes the Cargo version hash and date in the cache key to prevent this problem.