### PR TITLE
chore(deps): bump actions/cache dependency version to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
     # See <https://github.com/actions/cache>.
     - name: Create cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ inputs.cargo-home }}/bin/


### PR DESCRIPTION
## Context 
With Node 16 reaching End-of-life, Github actions deprecated it as runner of the GitHub actions on Sept 2023 (see: [GitHub Actions: Transitioning from Node 16 to Node 20
](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)).

![image](https://github.com/Leafwing-Studios/cargo-cache/assets/3949095/36b005fb-967e-4665-b0f6-455e615a6efe)

## Proposed fix

To fix the deprecation warning, this PR updates the `actions/checkout` action to the new major version, **v4**, using the new runtime recommended version: Node 20.


