### PR TITLE
feat: save cache on job failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ jobs:
 
 ## Inputs
 
-| Name               | Description                                                                                                                                                                                                                                                   | Type     | Default             |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `cache-group`      | The group of the cache, defaults to the job ID. If you want two jobs to share the same cache, give them the same group name.                                                                                                                                  | `string` | `${{ github.job }}` |
-| `cargo-home`       | The location of the Cargo cache files. If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory.                                                               | `string` | `~/.cargo`          |
-| `cargo-target-dir` | Location of where to place all generated artifacts, relative to the current working directory. If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory. | `string` | `target`            |
+| Name               | Description                                                                                                                                                                                                                                                   | Type      | Default             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------- |
+| `cache-group`      | The group of the cache, defaults to the job ID. If you want two jobs to share the same cache, give them the same group name.                                                                                                                                  | `string`  | `${{ github.job }}` |
+| `cargo-home`       | The location of the Cargo cache files. If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory.                                                               | `string`  | `~/.cargo`          |
+| `cargo-target-dir` | Location of where to place all generated artifacts, relative to the current working directory. If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory. | `string`  | `target`            |
+| `save-always`      | Run the post step to save the cache even if another step before fails.                                                                                                                                                                                        | `boolean` | `true`              |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
       Defaults to `target`.
     required: false
     default: target
+  save-always:
+    description: |
+      Run the post step to save the cache even if another step before fails.
+      Defaults to `true`.
+    required: false
+    default: true
 outputs:
   cache-hit:
     description: |
@@ -81,6 +87,7 @@ runs:
       id: cache
       uses: actions/cache@v4
       with:
+        save-always: ${{ inputs.save-always }}
         path: |
           ${{ inputs.cargo-home }}/bin/
           ${{ inputs.cargo-home }}/registry/index/


### PR DESCRIPTION
## Context

As stated by @TimJentzsch in #14:

> Unfortunately, the cache action only saves the cache if the workflow succeeded.
For cargo, this doesn't make much sense as e.g. a failing test doesn't influence the build artifacts.
> 
> The difficulty here is that the action does not provide any option to configure this.
We could use the [actions/cache@main/save](https://github.com/actions/cache/tree/main/save?rgh-link-date=2023-08-06T17%3A57%3A37Z) action to manually save the cache, but then we can't put it at the end of the job, since compose actions don't have a way to set a post action to my knowledge...

## Proposed Solution

The `actions/cache` action was upgraded to `v4` in the previous pull request. This update brought forth the `save-always` option, allowing the cache to be preserved even in the event of a preceding step failure.

To align with this enhancement, I am introducing the `save-always` action input to the `cargo-cache` action and cascading it to the internal `actions/cache` step. If the `save-always` action parameter is not set, by default, the cache will always be saved.

This PR resolves #14