### PR TITLE
Reset cache when workflow file changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,22 @@ runs:
 
         # Write the extracted version to a GitHub output variable
         # See <https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions>
-        echo "cargo-version=$(echo $version)" >> $GITHUB_OUTPUT
+        echo "cargo-version=$(echo $version)" >> "${GITHUB_OUTPUT}"
+
+    # The workflow file specifies the cargo command that will be run.
+    # If the cargo command changes, the previous cache will be outdated.
+    - name: Get workflow path
+      id: workflow-path
+      shell: bash
+      run: |
+          WORKFLOW_REF='${{ github.workflow_ref }}'
+          
+          # Strip git ref suffix
+          WORKFLOW_ABS_PATH="${WORKFLOW_REF%%@*}"
+          # Strip repository prefix
+          WORKFLOW_PATH="${WORKFLOW_ABS_PATH#'${{ github.repository }}/'}"
+          
+          echo "WORKFLOW_PATH=${WORKFLOW_PATH}" >> "${GITHUB_ENV}"
 
     # See <https://github.com/actions/cache>.
     - name: Create cache
@@ -94,11 +109,17 @@ runs:
           ${{ inputs.cargo-home }}/registry/cache/
           ${{ inputs.cargo-home }}/git/db/
           ${{ inputs.cargo-target-dir }}/
-        # Update the cache every time the `Cargo.lock` file changes (i.e., the dependencies change).
-        # We also include the `Cargo.toml` files in the hash in case the compile configurations change.
-        # The Cargo version is also included in the hash, because a version change causes re-compiles
-        key: ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        # Don't share a cache between different values of the following:
+        # - `cache-group`     (user-defined)
+        # - `runner.os`       (build platform)
+        # Reset the cache any time one of the following changes:
+        # - `cargo --version` (build toolchain)
+        # - Workflow file     (build commands)
+        # Restore from a fallback cache any time one of the following changes:
+        # - `Cargo.toml` file (build configs)
+        # - `Cargo.lock` file (build dependencies)
+        key: ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         # Restore caches from the same group.
         restore-keys: |
-          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-
-          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ inputs.cache-group }}-
+          ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ hashFiles('**/Cargo.toml') }}-
+          ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-

--- a/action.yml
+++ b/action.yml
@@ -82,8 +82,8 @@ runs:
         # See <https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions>
         echo "cargo-version=$(echo $version)" >> "${GITHUB_OUTPUT}"
 
-    # The workflow file specifies the cargo command that will be run.
-    # If the cargo command changes, the previous cache will be outdated.
+    # The workflow file determines which cargo commands will run.
+    # If the workflow file changes, the commands may be different, so the old cache may be outdated.
     - name: Get workflow path
       id: workflow-path
       shell: bash
@@ -112,10 +112,10 @@ runs:
         # Don't share a cache between different values of the following:
         # - `cache-group`     (user-defined)
         # - `runner.os`       (build platform)
-        # Reset the cache any time one of the following changes:
+        # Reset the cache whenever one of the following changes:
         # - `cargo --version` (build toolchain)
         # - Workflow file     (build commands)
-        # Restore from a fallback cache any time one of the following changes:
+        # Restore from a fallback cache whenever one of the following changes:
         # - `Cargo.toml` file (build configs)
         # - `Cargo.lock` file (build dependencies)
         key: ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
           ${{ inputs.cargo-home }}/registry/cache/
           ${{ inputs.cargo-home }}/git/db/
           ${{ inputs.cargo-target-dir }}/
-        # Don't share a cache between different values of the following:
+        # Never share a cache between different values of the following:
         # - `cache-group`     (user-defined)
         # - `runner.os`       (build platform)
         # Reset the cache whenever one of the following changes:

--- a/action.yml
+++ b/action.yml
@@ -110,16 +110,16 @@ runs:
           ${{ inputs.cargo-home }}/git/db/
           ${{ inputs.cargo-target-dir }}/
         # Never share a cache between different values of the following:
-        # - `cache-group`     (user-defined)
         # - `runner.os`       (build platform)
+        # - `cache-group`     (workflow job, or user-defined)
         # Reset the cache whenever one of the following changes:
+        # - Workflow file     (workflow contents)
         # - `cargo --version` (build toolchain)
-        # - Workflow file     (build commands)
         # Restore from a fallback cache whenever one of the following changes:
         # - `Cargo.toml` file (build configs)
         # - `Cargo.lock` file (build dependencies)
-        key: ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         # Restore caches from the same group.
         restore-keys: |
-          ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ hashFiles('**/Cargo.toml') }}-
-          ${{ inputs.cache-group }}-${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles(env.WORKFLOW_PATH) }}-
+          ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,6 @@ inputs:
       The group of the cache, defaults to a unique identifier for the workflow job.
       If you want two jobs to share the same cache, give them the same group name.
     required: false
-    default: ${{ github.job }}-${{ strategy.job-index }}
   cargo-home:
     description: |
       The location of the Cargo cache files.

--- a/action.yml
+++ b/action.yml
@@ -117,15 +117,14 @@ runs:
           ${{ inputs.cargo-target-dir }}/
         # Never share a cache between different values of the following:
         # - `runner.os`       (build platform)
-        # Reset the cache whenever one of the following changes:
         # - `cargo --version` (build toolchain)
         # Restore from a fallback cache whenever one of the following changes:
+        # - `cache-group`     (workflow job, or user-defined)
         # - `Cargo.toml` file (build configs)
         # - `Cargo.lock` file (build dependencies)
-        # - `cache-group`     (workflow job, or user-defined)
-        key: ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}-${{ steps.cache-group.outputs.cache-group }}
+        key: ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ steps.cache-group.outputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         # Restore caches from the same group.
         restore-keys: |
-          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}-
-          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-
-          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-
+          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ steps.cache-group.outputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ steps.cache-group.outputs.cache-group }}-
+          ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-

--- a/action.yml
+++ b/action.yml
@@ -117,14 +117,15 @@ runs:
           ${{ inputs.cargo-target-dir }}/
         # Never share a cache between different values of the following:
         # - `runner.os`       (build platform)
-        # - `cache-group`     (workflow job, or user-defined)
         # Reset the cache whenever one of the following changes:
         # - `cargo --version` (build toolchain)
         # Restore from a fallback cache whenever one of the following changes:
         # - `Cargo.toml` file (build configs)
         # - `Cargo.lock` file (build dependencies)
-        key: ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        # - `cache-group`     (workflow job, or user-defined)
+        key: ${{ runner.os }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}-${{ steps.cache-group.outputs.cache-group }}
         # Restore caches from the same group.
         restore-keys: |
+          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}-
           ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-
           ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,10 @@ description: Cache cargo build files and the registry
 inputs:
   cache-group:
     description: |
-      The group of the cache, defaults to the job ID.
+      The group of the cache, defaults to a unique identifier for the workflow job.
       If you want two jobs to share the same cache, give them the same group name.
     required: false
-    default: ${{ github.job }}
+    default: ${{ github.job }}-${{ strategy.job-index }}
   cargo-home:
     description: |
       The location of the Cargo cache files.
@@ -82,20 +82,27 @@ runs:
         # See <https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions>
         echo "cargo-version=$(echo $version)" >> "${GITHUB_OUTPUT}"
 
-    # The workflow file determines which cargo commands will run.
-    # If the workflow file changes, the commands may be different, so the old cache may be outdated.
+    # If the workflow file's contents change, the new version's jobs should be considered distinct.
     - name: Get workflow path
-      id: workflow-path
       shell: bash
       run: |
-          WORKFLOW_REF='${{ github.workflow_ref }}'
-          
-          # Strip git ref suffix
-          WORKFLOW_ABS_PATH="${WORKFLOW_REF%%@*}"
-          # Strip repository prefix
-          WORKFLOW_PATH="${WORKFLOW_ABS_PATH#'${{ github.repository }}/'}"
-          
-          echo "WORKFLOW_PATH=${WORKFLOW_PATH}" >> "${GITHUB_ENV}"
+        workflow_ref='${{ github.workflow_ref }}'
+        # Strip git ref suffix
+        workflow_abs_path="${workflow_ref%%@*}"
+        # Strip repository prefix
+        echo "workflow_path=${workflow_abs_path#'${{ github.repository }}/'}" >> "${GITHUB_ENV}"
+
+    - name: Determine cache group
+      id: cache-group
+      shell: bash
+      run: |
+        if [ -n '${{ inputs.cache-group }}' ]; then
+          # Use the `cache-group` input if it was provided.
+          echo 'cache-group=${{ inputs.cache-group }}' >> "${GITHUB_OUTPUT}"
+        else
+          # If not, fall back to a unique identifier for the workflow job.
+          echo 'cache-group=${{ hashFiles(env.WORKFLOW_PATH) }}-${{ github.job }}-${{ strategy.job-index }}' >> "${GITHUB_OUTPUT}"
+        fi
 
     # See <https://github.com/actions/cache>.
     - name: Create cache
@@ -113,13 +120,12 @@ runs:
         # - `runner.os`       (build platform)
         # - `cache-group`     (workflow job, or user-defined)
         # Reset the cache whenever one of the following changes:
-        # - Workflow file     (workflow contents)
         # - `cargo --version` (build toolchain)
         # Restore from a fallback cache whenever one of the following changes:
         # - `Cargo.toml` file (build configs)
         # - `Cargo.lock` file (build dependencies)
-        key: ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         # Restore caches from the same group.
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-
-          ${{ runner.os }}-${{ inputs.cache-group }}-${{ hashFiles(env.WORKFLOW_PATH) }}-${{ steps.cargo-version.outputs.cargo-version }}-
+          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-${{ hashFiles('**/Cargo.toml') }}-
+          ${{ runner.os }}-${{ steps.cache-group.outputs.cache-group }}-${{ steps.cargo-version.outputs.cargo-version }}-


### PR DESCRIPTION
While working on `bevy-template`, we noticed the CI was constantly recompiling. It turns out that when we modified the `ci.yaml` file with different cargo commands, the cache became outdated and every "cache hit" was a false positive. But the cache never updated because we never changed `Cargo.toml` or `Cargo.lock`.