### PR TITLE
fix: Cargo.lock command not found issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
 
         # Check if `Cargo.lock` exists.
         if [ -f "${ROOT_LOCKFILE}" ]; then
-          echo "Reusing existing `Cargo.lock` file."
+          echo 'Reusing existing `Cargo.lock` file.'
         else 
           echo "Cargo.lock file does not exist, creating it..."
 


### PR DESCRIPTION
For _bash_, backticks are known as _command substitution_. Thus, _bash_ evaluates the commands within and replaces them with the output.

![image](https://github.com/user-attachments/assets/83e59a21-22ba-4ee8-b0fb-d7574cb84d43)

The backticks can be escaped by replacing the double quotes with single quotes, and the `echo` command works as expected.