### PR TITLE
Update to `cargo-sweep` to v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Cache build files
         # This will call `action.yml`.
         uses: ./
-        with:
-          sweep-cache: true
 
       - name: Build Rust project
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Cache build files
         # This will call `action.yml`.
         uses: ./
+        with:
+          sweep-cache: true
 
       - name: Build Rust project
         run: cargo build

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 | `save-if`          | A condition which determines whether the cache should be saved. Otherwise, it's only restored                                                                                                                                                                 | `boolean` | `true`                                                                         |
 | `save-always`      | Run the post step to save the cache even if another step before fails.                                                                                                                                                                                        | `boolean` | `true`                                                                         |
 |`sweep-cache`|Use `cargo-sweep` to automatically delete files in the target folder that are not used between when this action is called and the end of the workflow. This can prevent the size of caches steadily increasing, since new caches are generated from fallback caches that may include stale artifacts.|`boolean`|`false`|
-|`cache-cargo-sweep`|Only has effect if `sweep-cache` is true. `sweep-cache` works by using [`cargo-sweep`], which is built using `cargo install`. If `cache-cargo-sweep` is true, this action will save the resulting binary to its own cache so that it does not need to be rebuilt in subsequent runs.|`boolean`|`true`|
+|`cache-cargo-sweep`|This input has been deprecated and will be removed in v3.0.0. It has no effect.|`boolean`||
 
 [`cargo-sweep`]: https://crates.io/crates/cargo-sweep
 

--- a/action.yml
+++ b/action.yml
@@ -188,10 +188,7 @@ runs:
           ${{ runner.os }}-${{ steps.rust-version.outputs.rust-version }}-${{ steps.cache-group.outputs.cache-group }}-
 
     - name: Sweep cache
-      uses: BD103/cargo-sweep@v1
-      if: ${{ inputs.sweep-cache }}
+      uses: BD103/cargo-sweep@v2
+      if: ${{ inputs.sweep-cache == 'true' }}
       with:
-        use-cache: ${{ inputs.cache-cargo-sweep }}
-        # Prebuilt binaries are discouraged now that caching is supported. While it is false by
-        # default, this is a precautionary measure that opts-out.
-        use-prebuilt: false
+        manifest-path: ${{ inputs.manifest-path }}

--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,8 @@ inputs:
     default: "false"
   cache-cargo-sweep:
     description: |
-      Only has effect if `sweep-cache` is true. `sweep-cache` works by using `cargo-sweep`, which
-      is built using `cargo install`. If `cache-cargo-sweep` is enabled, this action will save the
-      resuilting binary to its own cache so that it does not need to be rebuilt.
+      This input has been deprecated and will be removed in v3.0.0. It has no effect.
     required: false
-    default: "true"
 outputs:
   cache-hit:
     description: |
@@ -186,6 +183,11 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ steps.rust-version.outputs.rust-version }}-${{ steps.cache-group.outputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-
           ${{ runner.os }}-${{ steps.rust-version.outputs.rust-version }}-${{ steps.cache-group.outputs.cache-group }}-
+
+    - name: Log that `cache-cargo-sweep` is deprecated
+      if: ${{ inputs.cache-cargo-sweep }}
+      run: |
+        echo '::warning title=`cache-cargo-sweep` is deprecated::With updates to `BD103/cargo-sweep`, it no longer has any effect. It will be removed in v3.0.0.'
 
     - name: Sweep cache
       uses: BD103/cargo-sweep@v2

--- a/action.yml
+++ b/action.yml
@@ -186,6 +186,7 @@ runs:
 
     - name: Log that `cache-cargo-sweep` is deprecated
       if: ${{ inputs.cache-cargo-sweep }}
+      shell: bash
       run: |
         echo '::warning title=`cache-cargo-sweep` is deprecated::With updates to `BD103/cargo-sweep`, it no longer has any effect. It will be removed in v3.0.0.'
 


### PR DESCRIPTION
[Please see the release notes here.](https://github.com/BD103/cargo-sweep/releases/tag/v2.0.0) Closes #36.

This PR updates our dependency on `BD103/cargo-sweep` to v2.0.0. In the process it deprecates the `cache-cargo-sweep` input, since that no longer has any effect. (The `cargo-sweep` binary is no longer installed, instead its logic is replicated by the action in Javascript.)

This also fixes a bug where `cargo-sweep` was run even when set to `false`. Oops!

I specifically made this change backwards-compatible so it can be released in v2.5.0. Once v3.0.0 is released, we can permanently remove `cache-cargo-sweep` and set `sweep-cache` to `true` by default.