### PR TITLE
Replace input table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,8 @@ jobs:
 
 ## Outputs
 
-| Name        | Description                                                          | Type      | Note                                            |
-| ----------- | -------------------------------------------------------------------- | --------- | ----------------------------------------------- |
-| `cache-hit` | A boolean value to indicate if an exact match was found for the key. | `boolean` | Passed through from the `actions/cache` action. |
+- `cache-hit`: A string value that indicates if an exact match was found for the key.
+  - This is passed from `actions/cache`, so please see [its output documentation](https://github.com/actions/cache/tree/v4#outputs) for more information.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,53 @@ jobs:
 
 ## Inputs
 
-| Name               | Description                                                                                                                                                                                                                                                   | Type      | Default                                                                        |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------ |
-| `cache-group`      | The group of the cache, defaults to a unique identifier for the workflow job. If you want two jobs to share the same cache, give them the same group name.                                                                                                    | `string`  | `${{ hashFiles(env.workflow_path)-${{ github.job }}-${{ strategy.job-index }}` |
-| `cargo-home`       | The location of the Cargo cache files. If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory.                                                               | `string`  | `~/.cargo`                                                                     |
-| `cargo-target-dir` | Location of where to place all generated artifacts, relative to the current working directory. If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too. This must NOT end with the trailing slash of the directory. | `string`  | `target`                                                                       |
-|`manifest-path`|The path to `Cargo.toml`. This is used to determine where `Cargo.lock` is, which is used in the cache key.|`string`|`Cargo.toml`|
-| `save-if`          | A condition which determines whether the cache should be saved. Otherwise, it's only restored                                                                                                                                                                 | `boolean` | `true`                                                                         |
-| `save-always`      | Run the post step to save the cache even if another step before fails.                                                                                                                                                                                        | `boolean` | `true`                                                                         |
-|`sweep-cache`|Use `cargo-sweep` to automatically delete files in the target folder that are not used between when this action is called and the end of the workflow. This can prevent the size of caches steadily increasing, since new caches are generated from fallback caches that may include stale artifacts.|`boolean`|`false`|
-|`cache-cargo-sweep`|Only has effect if `sweep-cache` is true. `sweep-cache` works by using [`cargo-sweep`], which is built using `cargo install`. If `cache-cargo-sweep` is true, this action will save the resulting binary to its own cache so that it does not need to be rebuilt in subsequent runs.|`boolean`|`true`|
+```yaml
+- uses: Leafwing-Studios/cargo-cache@v2
+  with:
+    # The group of the cache, defaulting to a unique identifier for the workflow job.
+    #
+    # If you want two jobs to share the same cache, give them the same group name.
+    cache-group: ${{ hashFiles(env.workflow_path)-${{ github.job }}-${{ strategy.job-index }}`
 
-[`cargo-sweep`]: https://crates.io/crates/cargo-sweep
+    # The location of the Cargo home directory.
+    #
+    # If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too.
+    # This must *not* end with the trailing slash of the directory.
+    cargo-home: ~/.cargo
+
+    # The location where Cargo places all generated artifacts, relative to the current working
+    # directory.
+    #
+    # If you specify the `CARGO_TARGET_DIR` environmental variable or `--target-dir` for your
+    # commands, you need to set it here as well. This must *not* end with the trailing slash of the directory.
+    cargo-target-dir: target
+
+    # The path to `Cargo.toml`.
+    #
+    # This is used to determine where `Cargo.lock` and is, which is used in the cache key.
+    manifest-path: Cargo.toml
+
+    # Save the cache even if a previous step fails.
+    save-always: true
+
+    # Determines if the cache should be saved, or only loaded.
+    #
+    # Setting this to `false` will prevent new caches from being created.
+    save-if: true
+
+    # Automatically delete files in the target folder that are not used between when this action is
+    # called and the end of the job.
+    #
+    # This can prevent the size of caches snowballing. Since old caches are used to create new
+    # caches, unused files can slowly pile up over time, causing larger caches are longer runtimes.
+    sweep-cache: false
+
+    # Save the compiled `cargo-sweep` binary so that it can be downloaded from a cache in future
+    # runs.
+    #
+    # This only has effect if `sweep-cache` is true.
+    cache-cargo-sweep: true
+```
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,10 @@ inputs:
 outputs:
   cache-hit:
     description: |
-      A boolean value to indicate if an exact match was found for the key.
-      Passed through from the `actions/cache` action.
-    value: ${{ steps.cache.outputs.random-number }}
+      A string value that indicates if an exact match was found for the key.
+
+      This is passed through from the `actions/cache` action.
+    value: ${{ steps.cache.outputs.cache-hit }}
 runs:
   using: composite
   steps:

--- a/action.yml
+++ b/action.yml
@@ -3,57 +3,61 @@ description: Cache cargo build files and the registry
 inputs:
   cache-group:
     description: |
-      The group of the cache, defaults to a unique identifier for the workflow job.
+      The group of the cache, defaulting to a unique identifier for the workflow job.
+
       If you want two jobs to share the same cache, give them the same group name.
     required: false
   cargo-home:
     description: |
-      The location of the Cargo cache files.
+      The location of the Cargo home directory.
+
       If you specify the `CARGO_HOME` env variable for your commands, you need to set it here too.
-      This must NOT end with the trailing slash of the directory.
-      Defaults to `~/.cargo`.
+      This must *not* end with the trailing slash of the directory.
     required: false
     default: ~/.cargo
   cargo-target-dir:
     description: |
-      Location of where to place all generated artifacts, relative to the current working directory. 
-      If you specify the `CARGO_TARGET_DIR` env variable for your commands, you need to set it here too.
-      This must NOT end with the trailing slash of the directory.
-      Defaults to `target`.
+      The location where Cargo places all generated artifacts, relative to the current working
+      directory.
+
+      If you specify the `CARGO_TARGET_DIR` environmental variable or `--target-dir` for your
+      commands, you need to set it here as well. This must *not* end with the trailing slash of the
+      directory.
     required: false
     default: target
   manifest-path:
     description: |
-      The path to `Cargo.toml`. This is used to determine where `Cargo.lock` is, which is used in
-      the cache key.
-      Defaults to the `Cargo.toml` in the current working directory.
+      The path to `Cargo.toml`.
+
+      This is used to determine where `Cargo.lock` and is, which is used in the cache key.
     required: false
-    default: "Cargo.toml"
+    default: Cargo.toml
   save-always:
-    description: |
-      Run the post step to save the cache even if another step before fails.
-      Defaults to `true`.
+    description: Save the cache even if a previous step fails.
     required: false
     default: "true"
   save-if:
     description: |
-      A condition to determine whether the new cache should be saved.
-      If it evaluates to `false`, the cache is only loaded.
+      Determines if the cache should be saved, or only loaded.
+
+      Setting this to `false` will prevent new caches from being created.
     required: false
     default: "true"
   sweep-cache:
     description: |
-      Use `cargo-sweep` to automatically delete files in the target folder that are not used
-      between when this action is called and the end of the workflow. This can prevent the size of
-      caches steadily increasing, since new caches are generated from fallback caches that may
-      include stale artifacts.
+      Automatically delete files in the target folder that are not used between when this action is
+      called and the end of the job.
+
+      This can prevent the size of caches snowballing. Since old caches are used to create new
+      caches, unused files can slowly pile up over time, causing larger caches are longer runtimes.
     required: false
     default: "false"
   cache-cargo-sweep:
     description: |
-      Only has effect if `sweep-cache` is true. `sweep-cache` works by using `cargo-sweep`, which
-      is built using `cargo install`. If `cache-cargo-sweep` is enabled, this action will save the
-      resuilting binary to its own cache so that it does not need to be rebuilt.
+      Save the compiled `cargo-sweep` binary so that it can be downloaded from a cache in future
+      runs.
+
+      This only has effect if `sweep-cache` is true.
     required: false
     default: "true"
 outputs:


### PR DESCRIPTION
This closes #34.

This PR:

- Replaces the inputs and outputs tables in the `README.md` to be a code block and a bulleted list, respectively.
  - I wasn't sure how to document outputs in code, so I used a bulleted list instead.
  - Note that `cache-hit` can be `"true"`, `"false"`, or `""`, depending on the scenario, so I modified our description to say it is a string instead of a boolean. Check out [the docs](https://github.com/actions/cache#outputs) for why this is.
- Improved the descriptions of all inputs and outputs to be consistent, and synchronized them across `action.yml` and `README.md`.
  - I removed explicit writing that said "Defaults to `value`", as the default is always documented nearby. Tell me what you think!
- Fixed a bug where the `cache-hit` output would never be true.
  - It set its value to `${{ steps.cache.outputs.random-number }}`, not `${{ steps.cache.outputs.cache-hit }}`.