### PR TITLE
Cache `.crates.toml` and `.crates2.json`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,10 +170,17 @@ runs:
       if: ${{ inputs.save-if == 'true' }}
       with:
         path: |
+          # Tracks crates installed with `cargo install`.
+          ${{ inputs.cargo-home }}/.crates.toml
+          ${{ inputs.cargo-home }}/.crates2.json
+          # Path to binaries installed with `cargo install`.
           ${{ inputs.cargo-home }}/bin/
+          # Cached files downloaded from <https://crates.io> and other registries.
           ${{ inputs.cargo-home }}/registry/index/
           ${{ inputs.cargo-home }}/registry/cache/
+          # `.git` folders from checked-out repositories.
           ${{ inputs.cargo-home }}/git/db/
+          # The `target` directory.
           ${{ inputs.cargo-target-dir }}/
         key: ${{ runner.os }}-${{ steps.rust-version.outputs.rust-version }}-${{ steps.cache-group.outputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
@@ -188,10 +195,17 @@ runs:
       if: ${{ inputs.save-if != 'true' }}
       with:
         path: |
+          # Tracks crates installed with `cargo install`.
+          ${{ inputs.cargo-home }}/.crates.toml
+          ${{ inputs.cargo-home }}/.crates2.json
+          # Path to binaries installed with `cargo install`.
           ${{ inputs.cargo-home }}/bin/
+          # Cached files downloaded from <https://crates.io> and other registries.
           ${{ inputs.cargo-home }}/registry/index/
           ${{ inputs.cargo-home }}/registry/cache/
+          # `.git` folders from checked-out repositories.
           ${{ inputs.cargo-home }}/git/db/
+          # The `target` directory.
           ${{ inputs.cargo-target-dir }}/
         key: ${{ runner.os }}-${{ steps.rust-version.outputs.rust-version }}-${{ steps.cache-group.outputs.cache-group }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |


### PR DESCRIPTION
`~/.cargo/.crates.toml` and `.crates2.json` are two files that track which programs are installed with `cargo install`. For example, my `.crates.toml` looks like this:

```toml
[v1]
"basic-http-server 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = ["basic-http-server"]
"bevy_lint 0.3.0-dev (git+https://github.com/TheBevyFlock/bevy_cli.git?branch=main#8a72365eb76fee55f1807f34fff44edcd04c12fe)" = [
    "bevy_lint",
    "bevy_lint_driver",
]
"cargo-binutils 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = [
    "cargo-cov",
    "cargo-nm",
    "cargo-objcopy",
    "cargo-objdump",
    "cargo-profdata",
    "cargo-readobj",
    "cargo-size",
    "cargo-strip",
    "rust-ar",
    "rust-cov",
    "rust-ld",
    "rust-lld",
    "rust-nm",
    "rust-objcopy",
    "rust-objdump",
    "rust-profdata",
    "rust-readobj",
    "rust-size",
    "rust-strip",
]
"cargo-bisect-rustc 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = ["cargo-bisect-rustc"]
# ...
```

By including these files by default, `cargo install` will continue without error if a binary is already installed (instead of erroring out):

```shell
# With `.crates.toml`
$ cargo install ...
Ignored package `bevy_lint v0.3.0-dev (https://github.com/TheBevyFlock/bevy_cli.git?branch=main#8a72365e)` is already installed, use --force to override

# Without `.crates.toml`
$ cargo install ...
error: binary `bevy_lint` already exists in destination
binary `bevy_lint_driver` already exists in destination
Add --force to overwrite
```